### PR TITLE
Perform proper serialization/deserialization of booleans.

### DIFF
--- a/lib/snowflake_elixir_ecto/adapters/snowflake.ex
+++ b/lib/snowflake_elixir_ecto/adapters/snowflake.ex
@@ -41,6 +41,7 @@ defmodule Ecto.Adapters.Snowflake do
     * `:password` - Password for your account.
     * `:warehouse` - Warehouse to use on Snowflake. If none set, will use default for the account.
     * `:account_name` - Account name. This is usually the name between the https:// and us-east-1 (or whatever region).
+    * `:role` - the role to connect with.
     * `:database` - the database to connect to.
     * `:schema` - the schema to connect to.
     * `:async` - If set to true, will issue a query then connect every `:async_interval` to see if the query has completed.

--- a/lib/snowflake_elixir_ecto/adapters/snowflake_type.ex
+++ b/lib/snowflake_elixir_ecto/adapters/snowflake_type.ex
@@ -13,12 +13,16 @@ defmodule SnowflakeExEcto.Type do
     {:ok, to_string(nanos_since_midnight)}
   end
 
-  def encode(value, :boolean), do: value
+  def encode(true, :boolean), do: "1"
+  def encode(false, :boolean), do: "0"
   def encode(value, :integer), do: {:ok, value}
   def encode(value, :naive_datetime), do: {:ok, NaiveDateTime.to_iso8601(value)}
   def encode(value, {:array, :string}), do: {:ok, value}
   def encode(value, :uuid), do: value
   def encode(value, type), do: {:ok, to_string(value)}
+
+  def decode("1", :boolean), do: {:ok, true}
+  def decode("0", :boolean), do: {:ok, false}
 
   def decode(value, :decimal) do
     {:ok, Decimal.new(value)}


### PR DESCRIPTION
The Snowflake API sends boolean column values as string `"0"`'s or `"1"`'s over the wire. We need to provide ecto with this information to pass back and forth between that and elixir runtimes.

Fixes #4 