### PR TITLE
Updates snowflake_elixir to use Ecto 3.10

### DIFF
--- a/lib/snowflake_elixir_ecto/connection.ex
+++ b/lib/snowflake_elixir_ecto/connection.ex
@@ -1,7 +1,7 @@
 defmodule Ecto.Adapters.Snowflake.Connection do
   @behaviour Ecto.Adapters.SQL.Connection
   @parent_as __MODULE__
-  alias Ecto.Query.{BooleanExpr, JoinExpr, QueryExpr, WithExpr}
+  alias Ecto.Query.{BooleanExpr, JoinExpr, QueryExpr, WithExpr, LimitExpr}
 
   @impl true
   def child_spec(opts) do
@@ -462,6 +462,10 @@ defmodule Ecto.Adapters.Snowflake.Connection do
   end
 
   defp limit(%{limit: nil}, _sources), do: []
+
+  defp limit(%{limit: %LimitExpr{expr: expr}} = query, sources) do
+    [" LIMIT " | expr(expr, sources, query)]
+  end
 
   defp limit(%{limit: %QueryExpr{expr: expr}} = query, sources) do
     [" LIMIT " | expr(expr, sources, query)]

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule SnowflakeExEcto.MixProject do
 
   defp deps do
     [
-      {:snowflake_elixir, "~> 0.1.0"},
+      {:snowflake_elixir, "~> 0.2.0"},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule SnowflakeExEcto.MixProject do
   def project do
     [
       app: :snowflake_elixir_ecto,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       description: "Snowflake driver written in pure Elixir, using db_connection",


### PR DESCRIPTION
This PR also incorporates `LimitExpr` handling  to the connector.
